### PR TITLE
Update youtube-embed.imba

### DIFF
--- a/src/components/youtube-embed.imba
+++ b/src/components/youtube-embed.imba
@@ -23,7 +23,7 @@ tag youtube-embed
 		elif inline
 			<a href=video target="_target"> title
 			<div>
-				<button[c: white rd: 0.3rem bg: red p: 2] @click.pressedIcon> "Click for Video"
+				<button[c: white rd: 0.3rem bg: red p: 2 cursor: pointer] @click.pressedIcon> "Click for Video"
 		else
 			<.is-video>
 				<iframe.self-center src=video allowFullScreen="allowFullScreen" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; fullscreen;">


### PR DESCRIPTION
"Click for Video" was not shown as clickable, i.e. the cursor didn't switch to pointer:

<img width="510" alt="2020-09-25 12_29_35-Free Website for Notion to Anki Conversion" src="https://user-images.githubusercontent.com/68744864/94251880-d88cbc80-ff2b-11ea-8b6a-996d669646ea.png">

I fixed it:
<img width="501" alt="2020-09-25 12_35_35-Free Website for Notion to Anki Conversion" src="https://user-images.githubusercontent.com/68744864/94251920-e93d3280-ff2b-11ea-8040-4d0cae2597b5.png">
