### PR TITLE
Fixed the refferals typo

### DIFF
--- a/src/pages/useful-links.imba
+++ b/src/pages/useful-links.imba
@@ -20,7 +20,7 @@ tag useful-links-page
 					<hr>
 					<p.subtitle> "Here are some great resources to help you with your learning journey. Happy learning, my friend 🙂"
 
-					<h3[my: 2rem] .title .is-3> "Refferals"
+					<h3[my: 2rem] .title .is-3> "Referrals"
 					<hr>
 					<p.subtitle> "If you use the links to sign up to {<a href=digitalocean> "DigitalOcean"} or {<a href=skillshare> "Skillshare"} we get a reward 🎁 I am letting you know this for the sake of transparency 😉"
 					<.columns>


### PR DESCRIPTION
Fixed a typo (Refferals → Referrals).
I pointed this out in 
<img width="896" alt="2020-10-06 19_39_20-Free Website for Notion to Anki Conversion" src="https://user-images.githubusercontent.com/68744864/95231626-0c10f600-080c-11eb-82f0-a4d0410073bc.png">
a previous Zoom meeting.

_Please label as **hacktoberfest-accepted**, thanks 🙏🏻_