### PR TITLE
Change max-width from 90% to 80%

### DIFF
--- a/src/server/templates/custom.css
+++ b/src/server/templates/custom.css
@@ -14,7 +14,7 @@ body {
   border-radius: 8px;
   margin: 16px;
   max-width: 450px;
-  width: 90%;
+  width: 80%;
   display: inline-block;
 }
 


### PR DESCRIPTION
I saw what people were complaining about. 90% is too big for AnkiDroid. If you change it to 80% everything works fine.
Leave it like this for some time. If people continue to complain, I'll update the custom CSS to be more minimal and compatible. But I still think 80% max-width will solve the problem.